### PR TITLE
fix cmd fails when path contains spaces

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const ffmpegPath = require('@ffmpeg-installer/ffmpeg').path;
+const ffmpegPath = '\"' + require('@ffmpeg-installer/ffmpeg').path + '\"';
 const exec = require('child_process').exec;
 
 var extract = function (options,callback) {


### PR DESCRIPTION
Hi there, 

Sometimes, the command to execute ffmpeg will fail.
I found the reason is that path contains spaces, this happens on both Windows and macOS.
Therefore, I add double quotes around ffmpeg path to fix it.